### PR TITLE
Fix VERSION file location and how it is added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ sdist/
 .installed.cfg
 *.egg
 .DS_Store
+VERSION
 
 #CCC
 ccc_local_storage

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ ADD ./server/utils $APP/server/utils
 ADD ./server/views $APP/server/views
 ADD ./server/**.json $APP/server/
 
-RUN cp ./server/VERSION $APP/server/ || true
+ADD ./VERSION $APP/
 
 ENV PORT 4000
 EXPOSE $PORT

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Predictive molecular modeling applications based on the [Molecular Design Toolki
 	git clone https://github.com/Autodesk/molecular-design-applications
 	cd molecular-design-applications
 	git submodule update --init --recursive
+	echo "0.0.1-local" > VERSION
 	docker-compose up
 
 Then open your browser to  [http://localhost:4000](http://localhost:4000)


### PR DESCRIPTION
Dev notes: see the updated README.md, you now have to create the VERSION file in the project root for local startup. It's basically a huge PITA to _optionally_ get this file in when building docker containers. 