### PR TITLE
remove duplicative declaration of port 4000

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -4,10 +4,7 @@ services:
   server:
     build:
       context: .
-    ports:
-      - "4000:4000"
     environment:
-      PORT: "4000"
       CCC: "internal-lb.${BNR_ENVIRONMENT}.bionano.bio:9000"
     logging:
       driver: json-file

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,10 +7,7 @@ volumes:
 services:
   server:
     image: "quay.io/bionano/mdtapps_server:${VERSION}"
-    ports:
-      - "4000:4000"
     environment:
-      PORT: "4000"
       CCC: "ccc.bionano.autodesk.com:9000"
     logging:
       driver: json-file


### PR DESCRIPTION
When using docker-compose files as "override" files the ports section is merged across compose files. If the same port is declared twice in different files, this will cause a run-time error when `docker-compose up` is attempted. Other docker-compose commands, like `docker-compose build` will still work even though this error is present.