### PR TITLE
Fix test routes

### DIFF
--- a/server/main/server.js
+++ b/server/main/server.js
@@ -36,7 +36,7 @@ app.use(new express.Router().get('../assets/*', routeUtils.notFound));
 app.use(`${appConstants.VERSION_PREFIX}/workflow`, workflowRoutes);
 app.use(`${appConstants.VERSION_PREFIX}/run`, runRoutes);
 app.use(`${appConstants.VERSION_PREFIX}/structure`, structureRoutes);
-app.use(`${appConstants.VERSION_PREFIX}/test`, testRoutes);
+app.use('/test', testRoutes);
 app.use('/version', versionRouter);
 
 // API 404s

--- a/server/routes/test.js
+++ b/server/routes/test.js
@@ -6,7 +6,7 @@ const testUtils = require('../test/test_utils');
 
 const router = new express.Router();
 
-router.get('/test', (req, res) => {
+router.get('/', (req, res) => {
   testUtils.runTest2()
     .then((result) => {
       res.send({success:result.success});
@@ -15,7 +15,7 @@ router.get('/test', (req, res) => {
     });
 });
 
-router.get('/test-all', (req, res) => {
+router.get('/all', (req, res) => {
   testUtils.runAllTests()
     .then((result) => {
       res.send(result);


### PR DESCRIPTION
Moves `/v1/test/test` to `/test`.

I don't think it makes sense to version tests, I see they've been put with the version tag appended. Devops doesnt' care about versions, it just wants to hit `/test` and get a response. Checking versions, if that even makes sense here, should happen internally.