### PR TITLE
Molviewer Style Fixes

### DIFF
--- a/client/public/css/view.scss
+++ b/client/public/css/view.scss
@@ -2,7 +2,6 @@
   display: flex;
   justify-content: center;
   align-content: center;
-  height: 100%;
   flex: 1;
 }
 
@@ -24,4 +23,13 @@
     height: 75px;
     padding: 12px;
     margin: 0 auto;
+}
+
+#canvas3D {
+  vertical-align: middle;
+}
+
+/* TODO this should be removed in the molviewer instead of hacked out here */
+#guiviewer3d-toolbar {
+  display: none !important;
 }

--- a/client/public/css/workflow.scss
+++ b/client/public/css/workflow.scss
@@ -1,5 +1,5 @@
 .workflow {
   flex: 1;
-  height: 100%;
+  min-height: 100%;
   display: flex;
 }

--- a/client/public/js/components/workflow_router.jsx
+++ b/client/public/js/components/workflow_router.jsx
@@ -104,7 +104,7 @@ class WorkflowRouter extends React.Component {
     }
 
     return (
-      <div className="workflow-router" style={{ flex: 1 }}>
+      <div className="workflow-router" style={{ flex: 1, overflow: 'auto' }}>
         {routeEl}
         <Snackbar
           onMessageTimeout={this.props.onMessageTimeout}


### PR DESCRIPTION
This is the fix for the "Page/viewer formatting issues" listed in slack.  The navbar up top never gets squished now, and there are no more plain text "zoom/pan/etc" buttons.

<img width="1436" alt="screen shot 2017-02-10 at 11 07 22 am" src="https://cloud.githubusercontent.com/assets/389558/22840139/39c2c418-ef81-11e6-9f2d-78ee0cfa4095.png">

Anything else I'm missing?