### PR TITLE
Dev/prod URLs

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,8 +6,8 @@ services:
     environment:
       CCC: "ccc.bionano.autodesk.com:9000"
       NODE_ENV: "production"
-      FRONTEND_URL: "http://molsim.bionano.autodesk.com"
-      URL: "http://molsim.bionano.autodesk.com"
+      FRONTEND_URL: "http://molsim${BNR_ENV_URL_SUFFIX}.bionano.autodesk.com"
+      URL: "http://molsim${BNR_ENV_URL_SUFFIX}.bionano.autodesk.com"
       REDIS_HOST: "redis.${BNR_ENVIRONMENT}.bionano.bio"
     logging:
       driver: json-file


### PR DESCRIPTION
Previously, due to the env vars, the server though it was running on production even when it was on dev.  This PR distinguishes the two.