### PR TITLE
Results page show results step by default

### DIFF
--- a/client/public/js/reducers/selection.js
+++ b/client/public/js/reducers/selection.js
@@ -54,7 +54,7 @@ function selection(state = initialState, action) {
 
     case actionConstants.FETCHED_RUN:
       if (action.error ||
-        action.workflow.status !== statusConstants.COMPLETED) {
+        action.workflow.run.status !== statusConstants.COMPLETED) {
         return state;
       }
       return state.merge({


### PR DESCRIPTION
When loading the results of a run, the results step should be selected by default.