### PR TITLE
Let Server Handle 404s

### DIFF
--- a/server/main/server.js
+++ b/server/main/server.js
@@ -39,13 +39,13 @@ app.use(`${appConstants.VERSION_PREFIX}/structure`, structureRoutes);
 app.use('/test', testRoutes);
 app.use('/version', versionRouter);
 
-// API 404s
-app.use(new express.Router().get(`${appConstants.VERSION_PREFIX}/*`, routeUtils.notFound));
-
-// Redirect any other routes to index.html (single page app)
-app.use((req, res) => {
+// Serve index.html to page routes
+app.get(['/', '/workflow/*'], (req, res) => {
   res.sendFile(path.join(__dirname, '../../client/dist/index.html'));
 });
+
+// Everything else gives a 404
+app.use(routeUtils.notFound);
 
 // error handler
 app.use((err, req, res, next) => {


### PR DESCRIPTION
Previously, we would forward all page routes to index.html with status code 200 and let the frontend handle displaying a 404 page to the user.  This PR will only send index.html for existing routes and send an actual 404 for everything else.  When running on the live server, @PeterRJones's code will swap the 404 response for a standardized 404 page.

Note that nonexistent workflow and run pages (/workflow/invalid or /workflow/run/invalid) will still be handled by the frontend.  Also, it may still be possible to hit the unstyled frontend 404 page in the case that we have a bug that causes the frontend routing to direct the user to a nonexistent page without a full page refresh.